### PR TITLE
Add framerate display.

### DIFF
--- a/DataItem.cpp
+++ b/DataItem.cpp
@@ -11,6 +11,8 @@
 #include <vtkPolyDataMapper.h>
 #include <vtkProperty.h>
 #include <vtkSmartVolumeMapper.h>
+#include <vtkTextActor.h>
+#include <vtkTextProperty.h>
 #include <vtkVolume.h>
 #include <vtkVolumeProperty.h>
 
@@ -112,6 +114,16 @@ MooseViewer::DataItem::DataItem(void)
   this->actorCContour = vtkSmartPointer<vtkActor>::New();
   this->actorCContour->SetMapper(this->cContourMapper);
   ren->AddVolume(this->actorCContour);
+
+  this->framerate = vtkSmartPointer<vtkTextActor>::New();
+  this->framerate->GetTextProperty()->SetJustificationToLeft();
+  this->framerate->GetTextProperty()->SetVerticalJustificationToTop();
+  this->framerate->GetTextProperty()->SetFontSize(12);
+  this->framerate->SetTextScaleModeToViewport();
+  vtkCoordinate *fpsCoord = this->framerate->GetPositionCoordinate();
+  fpsCoord->SetCoordinateSystemToNormalizedDisplay();
+  fpsCoord->SetValue(0, 0.999);
+  ren->AddActor2D(this->framerate);
 }
 
 //----------------------------------------------------------------------------

--- a/DataItem.h
+++ b/DataItem.h
@@ -19,6 +19,7 @@ class vtkLookupTable;
 class vtkPiecewiseFunction;
 class vtkPolyDataMapper;
 class vtkSmartVolumeMapper;
+class vtkTextActor;
 class vtkVolume;
 
 struct MooseViewer::DataItem : public GLObject::DataItem
@@ -52,6 +53,8 @@ public:
   vtkSmartPointer<vtkContourFilter> cContour;
   vtkSmartPointer<vtkPolyDataMapper> cContourMapper;
   vtkSmartPointer<vtkActor> actorCContour;
+
+  vtkSmartPointer<vtkTextActor> framerate;
 
   /* Constructor and destructor*/
   DataItem(void);

--- a/MooseViewer.h
+++ b/MooseViewer.h
@@ -12,6 +12,7 @@
 #include <GLMotif/Slider.h>
 #include <GLMotif/TextField.h>
 #include <GLMotif/ToggleButton.h>
+#include <Misc/Timer.h>
 #include <Vrui/Application.h>
 
 // VTK includes
@@ -160,6 +161,11 @@ private:
   /* Custom scalar range */
   double* ScalarRange;
 
+  bool ShowFPS;
+  Misc::Timer FrameTimer;
+  std::vector<double> FrameTimes;
+  double GetFramesPerSecond() const;
+
   /* Constructors and destructors: */
 public:
   MooseViewer(int& argc,char**& argv);
@@ -177,6 +183,9 @@ public:
   /* Methods to set/get the widget hints file */
   void setWidgetHintsFile(const std::string &whFile);
   const std::string& getWidgetHintsFile(void);
+
+  void setShowFPS(bool show) { this->ShowFPS = show; }
+  bool getShowFPS() const { return this->ShowFPS; }
 
   /* Animation */
   bool IsPlaying;
@@ -222,6 +231,7 @@ public:
   void setScalarMaximum(double max);
 
   /* Callback methods */
+  void toggleFPSCallback(Misc::CallbackData* cbData);
   void centerDisplayCallback(Misc::CallbackData* cbData);
   void opacitySliderCallback(GLMotif::Slider::ValueChangedCallbackData* cbData);
   void sampleSliderCallback(GLMotif::Slider::ValueChangedCallbackData* cbData);

--- a/main.cpp
+++ b/main.cpp
@@ -18,6 +18,8 @@ void printUsage(bool longForm = true)
     std::cout << "\tName of ExodusII file to load using VTK.\n" << std::endl;
     std::cout << "\t-r <digit>, -renderMode <digit>" << std::endl;
     std::cout << "\tRender mode to request for vtkSmartVolumeMapper.\n" << std::endl;
+    std::cout << "\t-showfps" << std::endl;
+    std::cout << "\tShow the FPS display by default.\n" << std::endl;
     std::cout << "\t-widgetHints <path>" << std::endl;
     std::cout << "\tPath to a JSON file providing widget hints.\n" << std::endl;
     std::cout << "\t-h, -help" << std::endl;
@@ -46,6 +48,7 @@ int main(int argc, char* argv[])
     {
     std::string name;
     int renderMode = -1;
+    bool showFPS = false;
     std::string widgetHints;
     if(argc > 1)
       {
@@ -61,6 +64,10 @@ int main(int argc, char* argv[])
           {
           renderMode = atoi(argv[i+1]);
           ++i;
+          }
+        if(strcmp(argv[i], "-showfps")==0)
+          {
+          showFPS = true;
           }
         if(strcmp(argv[i], "-widgetHints")==0)
           {
@@ -83,6 +90,7 @@ int main(int argc, char* argv[])
       }
 
     MooseViewer application(argc, argv);
+    application.setShowFPS(showFPS);
     application.setWidgetHintsFile(widgetHints);
     application.Initialize();
 


### PR DESCRIPTION
Adds a vtkTextActor in the lower left corner that displays the average
FPS over the last 64 frames.

Adds a menu option to enable/disable the FPS display.

Adds a command line switch (-showfps) to turn on the FPS display.
